### PR TITLE
Fix torque coefficient in computeTorque

### DIFF
--- a/script.js
+++ b/script.js
@@ -292,7 +292,7 @@ function FAT_init(){
       if (ReOmega < 1) {
         return 8 * Math.PI * mu * (radius ** 3) * omega;
       } else {
-        let CtVal = 6.45 / Math.sqrt(ReOmega) + 35 / ReOmega;
+        let CtVal = 6.45 / Math.sqrt(ReOmega) + 32.1 / ReOmega;
         return 0.5 * CtVal * rho_air * (radius ** 5) * omega * Math.abs(omega);
       }
     }

--- a/trajectory.worker.js
+++ b/trajectory.worker.js
@@ -84,7 +84,7 @@ function computeTorque(omega, radius, rho_air, mu) {
   if (ReOmega < 1) {
     return 8 * Math.PI * mu * (radius ** 3) * omega;
   } else {
-    let CtVal = 6.45 / Math.sqrt(ReOmega) + 35 / ReOmega;
+    let CtVal = 6.45 / Math.sqrt(ReOmega) + 32.1 / ReOmega;
     return 0.5 * CtVal * rho_air * (radius ** 5) * omega * Math.abs(omega);
   }
 }


### PR DESCRIPTION
## Summary
- use 32.1 instead of 35 in `computeTorque` for script and worker
- keep `ReOmega` formulation intact

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68416c5a19b8832ea236bc68115575df