### PR TITLE
Add draggable hop‑up bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,28 +271,19 @@
                     <div>
                         <label class="block text-sm font-medium mb-1">Réglage Hop-up</label>
                         <div class="flex items-center space-x-2">
-                            <button id="hopupMinus" aria-label="Diminuer l’effet hop up"
-                                class="btn-primary px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded-md">
-                                <i class="fas fa-minus" aria-hidden="true"></i>
-                            </button>
                             <div class="flex-1">
                                 <div class="flex justify-between text-xs mb-1">
                                     <span>0%</span>
                                     <span>50%</span>
                                     <span>100%</span>
                                 </div>
-                                <div class="relative">
+                                <div id="hopupContainer" class="relative cursor-pointer select-none">
                                     <div class="h-2 bg-gray-700 rounded-full overflow-hidden">
-                                        <div id="hopupBar" class="h-full bg-gradient-to-r from-blue-500 to-purple-500"
-                                            style="width: 44%"></div>
+                                        <div id="hopupBar" class="h-full bg-gradient-to-r from-purple-500 to-pink-500" style="width: 60%"></div>
                                     </div>
-                                    <span id="hopupDisplay" class="absolute top-0 right-0 text-xs">44%</span>
+                                    <span id="hopupDisplay" class="absolute top-0 right-0 text-xs">60%</span>
                                 </div>
                             </div>
-                            <button id="hopupPlus" aria-label="Augmenter l’effet hop up"
-                                class="btn-primary px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded-md">
-                                <i class="fas fa-plus" aria-hidden="true"></i>
-                            </button>
                         </div>
                     </div>
 

--- a/script.js
+++ b/script.js
@@ -50,8 +50,7 @@ function FAT_init(){
     const scopeAngleDisplay = document.getElementById('scopeAngleDisplay');
   
     // Hop-up
-    const hopupPlusButton = document.getElementById('hopupPlus');
-    const hopupMinusButton = document.getElementById('hopupMinus');
+    const hopupContainer = document.getElementById('hopupContainer');
     const hopupDisplay = document.getElementById('hopupDisplay');
     const hopupBar = document.getElementById('hopupBar');
   
@@ -1253,23 +1252,35 @@ function FAT_init(){
       updateResultsAndEnergies();
     });
   
-    // Hop-up
-    hopupPlusButton.addEventListener('click', () => {
-      if (hopUpPercentage < 100) {
-        hopUpPercentage += 0.25;
-        if (hopUpPercentage > 100) hopUpPercentage = 100;
-        updateHopupDisplay();
-        updateResultsAndEnergies();
-      }
-    });
-    hopupMinusButton.addEventListener('click', () => {
-      if (hopUpPercentage > 0) {
-        hopUpPercentage -= 0.25;
-        if (hopUpPercentage < 0) hopUpPercentage = 0;
-        updateHopupDisplay();
-        updateResultsAndEnergies();
-      }
-    });
+    // Hop-up drag on bar
+    function setHopFromClientX(clientX) {
+      const rect = hopupContainer.getBoundingClientRect();
+      let percent = ((clientX - rect.left) / rect.width) * 100;
+      if (percent < 0) percent = 0;
+      if (percent > 100) percent = 100;
+      percent = Math.round(percent / 0.25) * 0.25;
+      hopUpPercentage = percent;
+      updateHopupDisplay();
+      updateResultsAndEnergies();
+    }
+    let draggingHopup = false;
+    const startHopupDrag = e => {
+      draggingHopup = true;
+      setHopFromClientX(e.touches ? e.touches[0].clientX : e.clientX);
+      e.preventDefault();
+    };
+    const moveHopupDrag = e => {
+      if (!draggingHopup) return;
+      setHopFromClientX(e.touches ? e.touches[0].clientX : e.clientX);
+      e.preventDefault();
+    };
+    const endHopupDrag = () => { draggingHopup = false; };
+    hopupContainer.addEventListener('mousedown', startHopupDrag);
+    hopupContainer.addEventListener('touchstart', startHopupDrag);
+    document.addEventListener('mousemove', moveHopupDrag);
+    document.addEventListener('touchmove', moveHopupDrag);
+    document.addEventListener('mouseup', endHopupDrag);
+    document.addEventListener('touchend', endHopupDrag);
   
     // Angle de tir
     anglePlusButton.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- switch hop-up adjustment to a draggable bar
- remove + and – buttons
- update bar gradient (purple→pink)

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842ec8024c0832e886c7febe55dce37