### PR TITLE
Fix hop-up progress bar gradient

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,7 +279,7 @@
                                 </div>
                                 <div id="hopupContainer" class="relative cursor-pointer select-none">
                                     <div class="h-2 bg-gray-700 rounded-full overflow-hidden">
-                                        <div id="hopupBar" class="h-full bg-gradient-to-r from-purple-500 to-pink-500" style="width: 60%"></div>
+                                        <div id="hopupBar" class="h-full bg-gradient-to-r from-blue-400 to-purple-500" style="width: 60%"></div>
                                     </div>
                                     <span id="hopupDisplay" class="absolute top-0 right-0 text-xs">60%</span>
                                 </div>


### PR DESCRIPTION
## Summary
- correct the hop-up bar gradient so its fill is visible

## Testing
- `npx tailwindcss -i ./src/input.css -o ./src/output.css --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f33539f4832ea640e98e1690382a