### PR TITLE
Fix hop‑up gradient

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,7 +279,7 @@
                                 </div>
                                 <div id="hopupContainer" class="relative cursor-pointer select-none">
                                     <div class="h-2 bg-gray-700 rounded-full overflow-hidden">
-                                        <div id="hopupBar" class="h-full bg-gradient-to-r from-blue-400 to-purple-500" style="width: 60%"></div>
+                                        <div id="hopupBar" class="h-full" style="width: 60%; background: linear-gradient(to right, #ec4899, #a78bfa);"></div>
                                     </div>
                                     <span id="hopupDisplay" class="absolute top-0 right-0 text-xs">60%</span>
                                 </div>


### PR DESCRIPTION
## Summary
- update hop‑up bar to use pink and purple gradient instead of blue

## Testing
- `node -e "console.log('no tests')"`


------
https://chatgpt.com/codex/tasks/task_e_6842f443e298832e81f8ced252de16ca