### PR TITLE
Switch hop-up slider to pointer events

### DIFF
--- a/script.js
+++ b/script.js
@@ -1266,21 +1266,19 @@ function FAT_init(){
     let draggingHopup = false;
     const startHopupDrag = e => {
       draggingHopup = true;
-      setHopFromClientX(e.touches ? e.touches[0].clientX : e.clientX);
+      setHopFromClientX(e.clientX);
       e.preventDefault();
     };
     const moveHopupDrag = e => {
       if (!draggingHopup) return;
-      setHopFromClientX(e.touches ? e.touches[0].clientX : e.clientX);
+      setHopFromClientX(e.clientX);
       e.preventDefault();
     };
     const endHopupDrag = () => { draggingHopup = false; };
-    hopupContainer.addEventListener('mousedown', startHopupDrag);
-    hopupContainer.addEventListener('touchstart', startHopupDrag);
-    document.addEventListener('mousemove', moveHopupDrag);
-    document.addEventListener('touchmove', moveHopupDrag);
-    document.addEventListener('mouseup', endHopupDrag);
-    document.addEventListener('touchend', endHopupDrag);
+    hopupContainer.addEventListener('pointerdown', startHopupDrag, {passive:false});
+    document.addEventListener('pointermove', moveHopupDrag, {passive:false});
+    document.addEventListener('pointerup', endHopupDrag);
+    document.addEventListener('pointercancel', endHopupDrag);
   
     // Angle de tir
     anglePlusButton.addEventListener('click', () => {

--- a/src/input.css
+++ b/src/input.css
@@ -132,3 +132,7 @@ input:checked+.toggle-slider:before {
         flex-direction: column !important;
     }
 }
+
+#hopupContainer {
+  touch-action: none;
+}

--- a/src/output.css
+++ b/src/output.css
@@ -943,3 +943,4 @@ input:checked + .toggle-slider:before {
     }
   }
 }
+#hopupContainer{touch-action:none}


### PR DESCRIPTION
## Summary
- use pointer events for hop-up slider drag logic
- disable browser touch handling on the hop-up container
- regenerate output.css (manually)

## Testing
- `npm test` *(fails: Missing script)*
- `node node_modules/@tailwindcss/cli/dist/index.mjs -i ./src/input.css -o ./src/output.css --minify` *(fails: No prebuild or local build of @parcel/watcher found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f86c6054832ebd6000ec0e77ae3e