### PR TITLE
Preserve gas dataset line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/data/green-gas-pressure-curves.json -text


### PR DESCRIPTION
## What changed

- Marked the application gas dataset as immutable binary content for Git checkout purposes.

## Why

Git for Windows converted LF to CRLF in the working tree after checkout, which changed the dataset SHA-256 and failed the bit-for-bit invariance test even though the published blob was correct.

## Validation

- Dataset SHA-256: `8AAB3754FFE4E8B8D12D4864C3F376CFBB1BF041F00D317CA407A58AB0CA65D8`
- `npm test`: 82/82 passed.
- Dataset content is unchanged; only `.gitattributes` is added.
